### PR TITLE
Making package pip-installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
 from setuptools import setup, find_packages
 
+
 with open('README.md') as f:
         readme = f.read()
 
+
 with open('LICENSE') as f:
         license = f.read()
+
+
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 
 setup(
         name='shingles',
@@ -15,6 +22,6 @@ setup(
         author_email='steven.a.samson@gmail.com',
         url='https://github.com/steven-s/text-shingles',
         license=license,
-        packages=find_packages(exclude=('tests'))
+        packages=find_packages(exclude=('tests')),
+        install_requires=requirements
 )
-

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('LICENSE') as f:
         license = f.read()
 
 setup(
-        name='text-shingles',
+        name='shingles',
         version='0.0.1',
         description='k-shingles for text',
         long_description=readme,


### PR DESCRIPTION
Previous to my fix it was problematic to install package as it had '-' in name in setup.py which is invalid for Python projects.

Now you can just install package with `pip install .` or even `pip install git+https://github.com/lambdaofgod/text-shingles`